### PR TITLE
Fix versioning errors on deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# This is a sandbox fork of the original, for exploration purposes.  Please refer to upstream for the definitive version.
+
 # Demo - Managed DCV solution
 &nbsp;
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-# This is a sandbox fork of the original, for exploration purposes.  Please refer to upstream for the definitive version.
-
 # Demo - Managed DCV solution
 &nbsp;
 

--- a/website/amplify.yml
+++ b/website/amplify.yml
@@ -1,0 +1,26 @@
+version: 1
+applications:
+  - backend:
+      phases:
+        build:
+          commands:
+            - '# Execute Amplify CLI with the helper script'
+            - update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python3.8 11
+            - /usr/local/bin/pip3.8 install --user pipenv
+            - amplifyPush --simple
+    frontend:
+      phases:
+        preBuild:
+          commands:
+            - yarn install
+        build:
+          commands:
+            - yarn run build
+      artifacts:
+        baseDirectory: build
+        files:
+          - '**/*'
+      cache:
+        paths:
+          - node_modules/**/*
+    appRoot: website

--- a/website/amplify/backend/analytics/dcvstartstop/pinpoint-cloudformation-template.json
+++ b/website/amplify/backend/analytics/dcvstartstop/pinpoint-cloudformation-template.json
@@ -244,7 +244,7 @@
           }
         },
         "Handler": "index.handler",
-        "Runtime": "nodejs10.x",
+        "Runtime": "nodejs14.x",
         "Timeout": "300",
         "Role": {
           "Fn::GetAtt": [

--- a/website/amplify/backend/auth/dcvstartstopc883f3ed/dcvstartstopc883f3ed-cloudformation-template.yml
+++ b/website/amplify/backend/auth/dcvstartstopc883f3ed/dcvstartstopc883f3ed-cloudformation-template.yml
@@ -372,6 +372,14 @@ Resources:
               Action:
                 - 'iam:PassRole'
               Resource: !If [ShouldNotCreateEnvResources, 'arn:aws:iam:::role/dcvstac883f3ed_totp_lambda_role', !Join ['',['arn:aws:iam:::role/dcvstac883f3ed_totp_lambda_role', '-', !Ref env]]]
+      - PolicyName: dcvstac883f3ed_sns_pass_role_policy
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action:
+                - 'iam:PassRole'
+              Resource: !GetAtt SNSRole.Arn
   MFALambda:
   # Lambda which sets MFA config values
   # Depends on MFALambdaRole for role ARN

--- a/website/amplify/backend/auth/dcvstartstopc883f3ed/dcvstartstopc883f3ed-cloudformation-template.yml
+++ b/website/amplify/backend/auth/dcvstartstopc883f3ed/dcvstartstopc883f3ed-cloudformation-template.yml
@@ -287,7 +287,7 @@ Resources:
             - ' }'
             - '};'
       Handler: index.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Timeout: '300'
       Role: !GetAtt 
         - UserPoolClientRole
@@ -415,7 +415,7 @@ Resources:
             - ' }'
             - '};'
       Handler: index.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Timeout: '300'
       Role: !GetAtt 
         - MFALambdaRole


### PR DESCRIPTION
Amplify build settings and backend template needed to be updated to work around dependency version errors and permissions.

- Changed nodejs version from nodejs10 to nodejs14 in backend templates (10 is deprecated now)
- Added Lambda MFARole policy to allow PassRole (lack of this causes issue)
- Updated the amplify.yml file to update python3 version alternatives (needs python 3.8 or later)